### PR TITLE
feat: stripping LAP dependency in favor of scipy 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = ""
 authors = ["R0flcopt3r <12752060+R0flcopt3r@users.noreply.github.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.8,<3.10"
 filterpy = "1.4.5"
-lap = "0.4.0"
+scipy = "1.7.0"
 
 [tool.poetry.dev-dependencies]
 debugpy = "^1.2.1"

--- a/sort/sort.py
+++ b/sort/sort.py
@@ -20,21 +20,15 @@ from __future__ import print_function
 import argparse
 import numpy as np
 from filterpy.kalman import KalmanFilter
+from scipy.optimize import linear_sum_assignment
 
 np.random.seed(0)
 
 
 def linear_assignment(cost_matrix):
-    try:
-        import lap
 
-        _, x, y = lap.lapjv(cost_matrix, extend_cost=True)
-        return np.array([[y[i], i] for i in x if i >= 0])  #
-    except ImportError:
-        from scipy.optimize import linear_sum_assignment
-
-        x, y = linear_sum_assignment(cost_matrix)
-        return np.array(list(zip(x, y)))
+    x, y = linear_sum_assignment(cost_matrix)
+    return np.array(list(zip(x, y)))
 
 
 def iou_batch(bb_test, bb_gt):


### PR DESCRIPTION
LAP is using deprecated install methods, and doesn't provide a wheel. An
check also exist to see if it is installed in the code, where it falls
back to scipy if not found.

Performance benchmarks shows both methods are within the same ballpark:

LAP
- 4.259107265002967s
- 4.466045453998959s
- 4.360787953002728s

scipy:
- 4.344673384002817s
- 4.282793791004224s
- 4.201874266997038s

this was run between every test to drop cache:

```
sudo sync; echo 1 | sudo tee /proc/sys/vm/drop_caches
```